### PR TITLE
fix: Set starting position(#86)

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -37,7 +37,7 @@ local function codeium_to_cmp(comp, offset, right)
 		start = {
 			-- Codeium returns an empy row for the first line
 			line = (tonumber(comp.range.startPosition.row) or 0),
-			character = offset,
+			character = offset - 1,
 		},
 		["end"] = {
 			-- Codeium returns an empy row for the first line


### PR DESCRIPTION
i got problem(#86) caused by [#68e387c](https://github.com/jcdickinson/codeium.nvim/commit/68e387cf96d53b2cfa325b44f2fae72a82e9f1a8)

so i added -1 again, and.. it seems work to me!