### PR TITLE
Add ability to override language server's download url.

### DIFF
--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -5,7 +5,7 @@ function M.defaults()
 		manager_path = nil,
 		bin_path = vim.fn.stdpath("cache") .. "/codeium/bin",
 		config_path = vim.fn.stdpath("cache") .. "/codeium/config.json",
-		override_download_url = "https://github.com",
+		language_server_download_url = "https://github.com",
 		api = {
 			host = "server.codeium.com",
 			port = "443",

--- a/lua/codeium/update.lua
+++ b/lua/codeium/update.lua
@@ -5,7 +5,7 @@ local notify = require("codeium.notify")
 local M = {}
 
 local cached = nil
-local override_download_url = "https://github.com"
+local language_server_download_url = "https://github.com"
 function M.get_bin_info()
 	if cached then
 		return cached
@@ -18,8 +18,8 @@ function M.get_bin_info()
 		return cached
 	end
 	
-    if config.options.override_download_url then
-		override_download_url = config.options.override_download_url
+    if config.options.language_server_download_url then
+		language_server_download_url = config.options.language_server_download_url
 	end
 	
 	local os_info = io.get_system_info()
@@ -37,7 +37,7 @@ function M.get_bin_info()
 		dir = dir,
 		bin_sufix = bin_sufix,
 		bin = dir .. "/" .. "language_server_" .. bin_sufix,
-		download_url = override_download_url
+		download_url = language_server_download_url
 		    .. "/Exafunction/codeium/releases/download/language-server-v"
 			.. versions.extension
 			.. "/language_server_"

--- a/lua/codeium/update.lua
+++ b/lua/codeium/update.lua
@@ -5,6 +5,7 @@ local notify = require("codeium.notify")
 local M = {}
 
 local cached = nil
+local override_download_url = "https://github.com"
 function M.get_bin_info()
 	if cached then
 		return cached
@@ -16,7 +17,11 @@ function M.get_bin_info()
 		}
 		return cached
 	end
-
+	
+    if config.options.override_download_url then
+		override_download_url = config.options.override_download_url
+	end
+	
 	local os_info = io.get_system_info()
 	local dir = config.options.bin_path .. "/" .. versions.extension
 	local bin_sufix
@@ -32,7 +37,8 @@ function M.get_bin_info()
 		dir = dir,
 		bin_sufix = bin_sufix,
 		bin = dir .. "/" .. "language_server_" .. bin_sufix,
-		download_url = "https://github.com/Exafunction/codeium/releases/download/language-server-v"
+		download_url = override_download_url
+		    .. "/Exafunction/codeium/releases/download/language-server-v"
 			.. versions.extension
 			.. "/language_server_"
 			.. bin_sufix


### PR DESCRIPTION
In some environments, github cannot be accessed directly, add `language_server_download_url`.

Config example:

`codeium.setup {
   language_server_download_url= "https://mirror.of.github.com",
}`