### PR TITLE
Use HTTP/2 Protocol for Heartbeat: Fixing Proxy Compatibility Issues

### DIFF
--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -206,7 +206,7 @@ function Server:new()
 			log.debug(j.pid .. ": " .. v)
 		end
 
-		local api_server_url = 'https://' .. config.options.api.host .. ':' .. config.options.api.port
+		local api_server_url = "https://" .. config.options.api.host .. ":" .. config.options.api.port
 		job = io.job({
 			update.get_bin_info().bin,
 			"--api_server_url",

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -146,6 +146,7 @@ function Server:new()
 		io.post(url, {
 			body = payload,
 			callback = callback,
+			http_version = "HTTP/2",
 		})
 	end
 


### PR DESCRIPTION
Hello,

I would like to submit a pull request that addresses the problem of Curl hanging when used behind a proxy. The proposed solution involves implementing the HTTP/2 protocol for the heartbeat feature.

Reason for the Change:
Currently, when Curl is used behind a proxy, it experiences a hang issue. This can cause hang the normal functioning of the application. By adopting the HTTP/2 protocol for the heartbeat feature, we aim to resolve this problem and ensure smooth operation even when utilized behind a proxy.

Please review this pull request at your convenience. I believe that implementing the HTTP/2 protocol will effectively tackle the Curl hang issue and improve the overall reliability of the application.

Thank you for your consideration.

Best regards,