### PR TITLE
Replace `buildVimPluginFrom2Nix` with `buildVimPlugin`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -17,23 +20,39 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674868155,
-        "narHash": "sha256-eFNm2h6fNbgD7ZpO4MHikCB5pSnCJ7DTmwPisjetmwc=",
+        "lastModified": 1702346276,
+        "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce20e9ebe1903ea2ba1ab006ec63093020c761cb",
+        "rev": "cf28ee258fd5f9a52de6b9865cdb93a1f96d09b7",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-22.11",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = {
@@ -39,9 +39,15 @@
             sourceRoot = ".";
 
             phases = ["installPhase" "fixupPhase"];
-            nativeBuildInputs = [
-              stdenv.cc.cc
-            ] ++ (if !stdenv.isDarwin then [ autoPatchelfHook ] else []);
+            nativeBuildInputs =
+              [
+                stdenv.cc.cc
+              ]
+              ++ (
+                if !stdenv.isDarwin
+                then [autoPatchelfHook]
+                else []
+              );
 
             installPhase = ''
               mkdir -p $out/bin

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
               install -m755 $src $out/bin/codeium-lsp
             '';
           };
-          vimPlugins.codeium-nvim = vimUtils.buildVimPluginFrom2Nix {
+          vimPlugins.codeium-nvim = vimUtils.buildVimPlugin {
             pname = "codeium";
             version = "v${versions.version}-main";
             src = ./.;


### PR DESCRIPTION
`buildVimPlugin2Nix` is deprecated; `buildVimPlugin` takes in the same arguments and outputs the same things, so only a quick line change is needed.