### PR TITLE
feat: Enterprise mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ your browser and pasting it into API token request.
 - `config_path`: the path to the config file, used to store the API key.
 - `bin_path`: the path to the directory where the Codeium server will be downloaded to.
 - `api`: information about the API server to use:
-  - `host`: the hostname
-  - `port`: the port
-  - `path`: the path prefix to the API server
-  - `portal_url`: the portal URL to use (for enterprise mode)
+  - `host`: the hostname. Example: `"codeium.example.com"`. Required when using enterprise mode
+  - `port`: the port. Defaults to `443`
+  - `path`: the path prefix to the API server. Default for enterprise: `"/_route/api_server"`
+  - `portal_url`: the portal URL to use (for enterprise mode). Defaults to `host:port`
 - `enterprise_mode`: enable enterprise mode
 - `detect_proxy`: enable or disable proxy detection
 - `tools`: paths to binaries used by the plugin:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ your browser and pasting it into API token request.
 - `api`: information about the API server to use:
   - `host`: the hostname
   - `port`: the port
+  - `path`: the path prefix to the API server
+  - `portal_url`: the portal URL to use (for enterprise mode)
+- `enterprise_mode`: enable enterprise mode
+- `detect_proxy`: enable or disable proxy detection
 - `tools`: paths to binaries used by the plugin:
 
   - `uname`: not needed on Windows, defaults given.
@@ -100,6 +104,8 @@ cmp.setup({
     }
 })
 ```
+
+If you are seeing the `codeium` source as unused in `:CmpStatus`, make sure that `nvim-cmp` setup happens before the `codeium.nvim` setup.
 
 To set a symbol for codeium using lspkind, use the `Codeium` keyword. Example:
 

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -68,9 +68,9 @@ function Server.authenticate()
 	local attempts = 0
 	local uuid = io.generate_uuid()
 	local url = "https://"
-		.. config.api.host
+		.. config.options.api.host
 		.. ":"
-		.. config.api.port
+		.. config.options.api.port
 		.. "/profile?response_type=token&redirect_uri=vim-show-auth-token&state="
 		.. uuid
 		.. "&scope=openid%20profile%20email&redirect_parameters_type=query"

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -229,7 +229,7 @@ function Server:new()
 
 		if config.options.api.portal_url then
 			table.insert(job_args, "--portal_url")
-			table.insert(job_args, config.options.api.portal_url)
+			table.insert(job_args, "https://" .. config.options.api.portal_url)
 		end
 
 		if config.options.enterprise_mode then

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -68,9 +68,7 @@ function Server.authenticate()
 	local attempts = 0
 	local uuid = io.generate_uuid()
 	local url = "https://"
-		.. config.options.api.host
-		.. ":"
-		.. config.options.api.port
+		.. config.options.api.portal_url
 		.. "/profile?response_type=token&redirect_uri=vim-show-auth-token&state="
 		.. uuid
 		.. "&scope=openid%20profile%20email&redirect_parameters_type=query"

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -9,7 +9,11 @@ function M.defaults()
 		api = {
 			host = "server.codeium.com",
 			port = "443",
+			path = "/",
+			portal_url = nil,
 		},
+		enterprise_mode = nil,
+		detect_proxy = nil,
 		tools = {},
 		wrapper = nil,
 	}

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -32,6 +32,10 @@ end
 
 function M.apply_conditional_defaults(options)
 	if options.enterprise_mode then
+		if options.api == nil then
+			options.api = {}
+		end
+
 		if options.api.path == nil then
 			options.api.path = "/_route/api_server"
 		end

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -44,7 +44,7 @@ function M.apply_conditional_defaults(options)
 			notify.warn("You need to specify api.host in enterprise mode")
 		else
 			if options.api.portal_url == nil then
-				options.api.portal_url = "https://" .. options.api.host .. ":" .. (options.api.port or "443")
+				options.api.portal_url = options.api.host .. ":" .. (options.api.port or "443")
 			end
 		end
 	end

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -1,3 +1,5 @@
+local notify = require("codeium.notify")
+
 local M = {}
 
 function M.defaults()
@@ -28,10 +30,31 @@ function M.installation_defaults()
 	end
 end
 
+function M.apply_conditional_defaults(options)
+	if options.enterprise_mode then
+		if options.api.path == nil then
+			options.api.path = "/_route/api_server"
+		end
+
+		if options.api.host == nil then
+			notify.warn("You need to specify api.host in enterprise mode")
+		else
+			if options.api.portal_url == nil then
+				options.api.portal_url = "https://" .. options.api.host .. ":" .. (options.api.port or "443")
+			end
+		end
+	end
+
+	return options
+end
+
 M.options = {}
 
 function M.setup(options)
 	options = options or {}
+
+	options = M.apply_conditional_defaults(options)
+
 	M.options = vim.tbl_deep_extend("force", {}, M.defaults(), M.installation_defaults(), options)
 end
 

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -10,7 +10,7 @@ function M.defaults()
 			host = "server.codeium.com",
 			port = "443",
 			path = "/",
-			portal_url = nil,
+			portal_url = "codeium.com",
 		},
 		enterprise_mode = nil,
 		detect_proxy = nil,

--- a/lua/codeium/log.lua
+++ b/lua/codeium/log.lua
@@ -1,6 +1,6 @@
 local p_debug = vim.env.DEBUG_CODEIUM
 
 return require("plenary.log").new({
-	plugin = "codeium",
+	plugin = "codeium/codeium.log",
 	level = p_debug or "info",
 })


### PR DESCRIPTION
In #141 there was a typo accessing `config.api` instead of `config.options.api`. This PR fixes that.

Also i found that my changes broke logging in because api host was different from portal url, so fixed that too.