### PR TITLE
Handle MINGW32_NT-10.0 sysname of MSYS2 on Windows 

### DIFF
--- a/lua/codeium/io.lua
+++ b/lua/codeium/io.lua
@@ -211,7 +211,7 @@ function M.get_system_info()
 		os = "linux"
 	elseif os == "Darwin" then
 		os = "macos"
-	elseif os == "Windows_NT" or os == "MINGW32_NT-10.0" then
+	elseif os == "Windows_NT" or string.find(os, "MINGW32_NT") then
 		os = "windows"
 	else
 		require("codeium.notify").warn("Unknown sysname: ", os)

--- a/lua/codeium/io.lua
+++ b/lua/codeium/io.lua
@@ -211,7 +211,7 @@ function M.get_system_info()
 		os = "linux"
 	elseif os == "Darwin" then
 		os = "macos"
-	elseif os == "Windows_NT" then
+	elseif os == "Windows_NT" or os == "MINGW32_NT-10.0" then
 		os = "windows"
 	else
 		require("codeium.notify").warn("Unknown sysname: ", os)


### PR DESCRIPTION
This PR fixes an issue where the `get_system_info()` function fails to recognize the "MINGW32_NT-10.0" sysname returned when running on Windows under MSYS2.

## Changes

- Update `get_system_info()` to check for "MINGW32_NT-10.0" sysname and handle it the same as "Windows_NT"

## Reason for Change

Currently, `get_system_info()` only checks for "Windows_NT" sysname to identify Windows. When running on MSYS2, the sysname is "MINGW32_NT-10.0" which causes `get_system_info()` to fail with an "Unknown sysname" warning. 

Checking for and handling MINGW32_NT-10.0 allows `get_system_info()` to work properly when running on Windows under MSYS2.
