### PR TITLE
Add workspace context to chat

### DIFF
--- a/lua/codeium/init.lua
+++ b/lua/codeium/init.lua
@@ -21,6 +21,7 @@ function M.setup(options)
 		end
 		if args[1] == "Chat" then
 			s.get_chat_ports()
+			s.add_workspace()
 		end
 	end, {
 		nargs = 1,

--- a/lua/codeium/init.lua
+++ b/lua/codeium/init.lua
@@ -26,7 +26,11 @@ function M.setup(options)
 	end, {
 		nargs = 1,
 		complete = function()
-			return { "Auth" }
+			local commands = {"Auth"}
+			if require("codeium.config").options.enable_chat then
+				commands = vim.list_extend(commands, {"Chat"})
+			end
+			return commands
 		end,
 	})
 


### PR DESCRIPTION
Fix issues:  #170

Known issues:
- [x]  I do not have NixOS and unable to provide correct hash256 values for the server
- [x]  Unable to add path to a hidden workspace. Error code returning from the server.
- [x]  The same path would be added one Codeium Chat command that's causing error code