### PR TITLE
Correct log location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cmp.setup({
 
 ## Troubleshooting
 
-The plugin log is written to `~/.cache/nvim/codeium.log`.
+The plugin log is written to `~/.cache/nvim/codeium/codeium.log`.
 
 You can set the logging level to one of `trace`, `debug`, `info`, `warn`,
 `error` by exporting the `DEBUG_CODEIUM` environment variable.


### PR DESCRIPTION
Unless I'm missing something, the correct location for these logs is actually in the `~/.cache/nvim/codeium` folder not `~/.cache/nvim`. That's where I found the logs on my machine anyway.

Let me know if you're seeing the logs in a different place.