### PR TITLE
Clarify log file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cmp.setup({
 
 ## Troubleshooting
 
-The plugin log is written to `~/.cache/nvim/codeium.log`.
+The plugin log is written to `~/.cache/nvim/codeium.log` or `~/.cache/nvim/codeium/codeium.log.log` depending on the platform.
 
 You can set the logging level to one of `trace`, `debug`, `info`, `warn`,
 `error` by exporting the `DEBUG_CODEIUM` environment variable.


### PR DESCRIPTION
The documentation says the locatio is `~/.cache/nvim/codeium.log` but at least on my mac the logfile is at `~/.cache/nvim/codeium/codeium.log.log` (note the double `.log.log`). 