### PR TITLE
completion request failed spam fixed.

### DIFF
--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -149,7 +149,7 @@ function Server.authenticate()
 	prompt()
 end
 
-function Server:new()
+function Server:new(options)
 	local m = {}
 	setmetatable(m, self)
 
@@ -374,6 +374,14 @@ function Server:new()
 				if err.status == 503 or err.status == 408 then
 					-- Service Unavailable or Timeout error
 					return complete(false, nil)
+				end
+
+				-- Ignore user defined errors
+				for _,ignored in pairs(options.ignored_errors or {}) do
+					if err.status == ignored then
+						log.warn("completion request failed", err.status)
+						return complete(false, nil)
+					end
 				end
 
 				local ok, json = pcall(vim.fn.json_decode, err.response.body)

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -22,6 +22,7 @@ function M.defaults()
 		enable_local_search = false,
 		enable_index_service = false,
 		search_max_workspace_file_count = 5000,
+		ignored_errors = nil,
 	}
 end
 

--- a/lua/codeium/init.lua
+++ b/lua/codeium/init.lua
@@ -7,7 +7,7 @@ function M.setup(options)
 	local health = require("codeium.health")
 	require("codeium.config").setup(options)
 
-	local s = Server:new()
+	local s = Server:new(options)
 	update.download(function(err)
 		if not err then
 			Server.load_api_key()


### PR DESCRIPTION
Hi! I've been facing a weird problem in codeium, sometimes it has bad days and often spams completion request failed errors and it forces me to press spacebar ~15 times in a row and its very frustrating. I have developed a solution where the user can expand the ignored api errors like (408 and 503) with frequently occurring ones. The user will still be notified of ignored errors, but this will not distract them. I also have screenshots from the error.
![image](https://github.com/user-attachments/assets/b95a4026-11cb-4f3a-8dd9-089ceabd760b)
![image2](https://github.com/user-attachments/assets/10dead79-f85c-42dd-a093-1547cc43cd63)
