### PR TITLE
feat: update getCompletions document body

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -182,11 +182,14 @@ function Source:complete(params, callback)
 
 	self.server.request_completion(
 		{
+			text = text,
 			editor_language = filetype,
 			language = language,
-			cursor_offset = cursor_offset,
-			text = text,
+			curson_position = { row = cursor.row, col = cursor.col },
+			absolute_path = vim.api.nvim_buf_get_name(bufnr),
+			relative_path = util.get_relative_path(bufnr),
 			line_ending = line_ending,
+			cursor_offset = cursor_offset,
 		},
 		editor_options,
 		other_documents,

--- a/lua/codeium/util.lua
+++ b/lua/codeium/util.lua
@@ -18,20 +18,24 @@ function M.get_editor_options(bufnr)
 
 	return {
 		tab_size = M.fallback_call({
-			{ vim.api.nvim_buf_get_option, bufnr,       "shiftwidth" },
-			{ vim.api.nvim_buf_get_option, bufnr,       "tabstop" },
-			{ vim.api.nvim_get_option,     "shiftwidth" },
-			{ vim.api.nvim_get_option,     "tabstop" },
+			{ vim.api.nvim_get_option_value, "shiftwidth", { buf = bufnr, } },
+			{ vim.api.nvim_get_option_value, "tabstop",    { buf = bufnr, } },
+			{ vim.api.nvim_get_option_value, "shiftwidth" },
+			{ vim.api.nvim_get_option_value, "tabstop" },
 		}, greater_than_zero, 4),
 		insert_spaces = M.fallback_call({
-			{ vim.api.nvim_buf_get_option, bufnr,      "expandtab" },
-			{ vim.api.nvim_get_option,     "expandtab" },
+			{ vim.api.nvim_get_option_value, "expandtab", { buf = bufnr, } },
+			{ vim.api.nvim_get_option_value, "expandtab" },
 		}, nil, true),
 	}
 end
 
 function M.get_newline(bufnr)
 	return enums.line_endings[vim.bo[bufnr].fileformat] or "\n"
+end
+
+function M.get_relative_path(bufnr)
+	return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":")
 end
 
 return M


### PR DESCRIPTION
Newer language servers require absolute path to be part of the request.

Tested locally with language server 1.14.11.

Also replaced deprecated functions in utils module.