### PR TITLE
Fix codeium log file name issue

### DIFF
--- a/lua/codeium/log.lua
+++ b/lua/codeium/log.lua
@@ -1,6 +1,6 @@
 local p_debug = vim.env.DEBUG_CODEIUM
 
 return require("plenary.log").new({
-	plugin = "codeium/codeium.log",
+	plugin = "codeium/codeium",
 	level = p_debug or "info",
 })


### PR DESCRIPTION
The codeium log file name is `codeium.log.log` now.
This PR fixes it to `codeium.log`