### PR TITLE
Fix LSP crash when opening chat

### DIFF
--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -442,8 +442,8 @@ function Server:new()
 			cursor_offset = 0,
 			text = text,
 			line_ending = line_ending,
-			absolute_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p"),
-			relative_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":"),
+			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
+			workspace_uri = util.get_uri(util.get_relative_path(bufnr)),
 		}
 
 		request("RefreshContextForIdeAction", {

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -443,7 +443,7 @@ function Server:new()
 			text = text,
 			line_ending = line_ending,
 			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
-			relative_path_migrate_me_to_workspace_uri = util.get_uri(util.get_relative_path(bufnr)),
+			relative_path_migrate_me_to_workspace_uri = util.get_relative_path(bufnr),
 		}
 
 		request("RefreshContextForIdeAction", {
@@ -453,8 +453,7 @@ function Server:new()
 				notify.error("failed refresh context: " .. err.out)
 				return
 			end
-		end
-		)
+		end)
 	end
 
 	function m.add_workspace()

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -443,7 +443,7 @@ function Server:new()
 			text = text,
 			line_ending = line_ending,
 			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
-			workspace_uri = util.get_uri(util.get_relative_path(bufnr)),
+			relative_path_migrate_me_to_workspace_uri = util.get_uri(util.get_relative_path(bufnr)),
 		}
 
 		request("RefreshContextForIdeAction", {

--- a/lua/codeium/util.lua
+++ b/lua/codeium/util.lua
@@ -36,7 +36,7 @@ function M.get_newline(bufnr)
 end
 
 function M.get_relative_path(bufnr)
-	return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":")
+	return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":.")
 end
 
 function M.get_uri(path)


### PR DESCRIPTION
LSP was crashing because the refresh_context function had not been updated for the new `_uri` based payload keys.

Fixes #238 