### PR TITLE
Find workspace root

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ in your default browser using the xdg-open command.
 - `enterprise_mode`: enable enterprise mode
 - `detect_proxy`: enable or disable proxy detection
 - `enable_chat`: enable chat functionality
+- `project_root_paths`: paths to files that indicate a workspace root
 - `tools`: paths to binaries used by the plugin:
 
   - `uname`: not needed on Windows, defaults given.
@@ -128,6 +129,27 @@ cmp.setup({
     }
 })
 ```
+
+### Workspace Root Directory
+
+For the chat feature, the plugin will determine the workspace root directory by searching upward from the
+current working directory for one of the files listed in the `project_root_paths` option.
+
+The default list of files and directories is
+
+```lua
+project_root_paths = {
+	".bzr",
+	".git",
+	".hg",
+	".svn",
+	"_FOSSIL_",
+	"package.json",
+}
+```
+
+You can replace this list by passing `project_root_paths` when calling `setup`. If none of these paths are
+found, the plugin will treat the current working directory as the root.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ in your default browser using the xdg-open command.
 - `enterprise_mode`: enable enterprise mode
 - `detect_proxy`: enable or disable proxy detection
 - `enable_chat`: enable chat functionality
-- `project_root_paths`: paths to files that indicate a workspace root
+- `workspace_root`:
+  - `use_lsp`: Use Neovim's LSP support to find the workspace root, if possible.
+  -	`paths`: paths to files that indicate a workspace root when not using the LSP support
+  - `find_root`: An optional function that the plugin will call to find the workspace root.
 - `tools`: paths to binaries used by the plugin:
 
   - `uname`: not needed on Windows, defaults given.
@@ -132,24 +135,45 @@ cmp.setup({
 
 ### Workspace Root Directory
 
-For the chat feature, the plugin will determine the workspace root directory by searching upward from the
-current working directory for one of the files listed in the `project_root_paths` option.
+The plugin uses a few techniques to find the workspace root directory, which helps to inform the autocomplete and chat context. 
 
-The default list of files and directories is
+1. Call the optional `workspace_root.find_root` function, if provided. This is described below.
+2. Query Neovim's built-in LSP support for the workspace root, if `workspace_root.use_lsp` is not set to `false`.
+3. Search upward in the filesystem for a file or directory in `workspace_root.paths` that indicates a workspace root.
+
+The default configuration is:
 
 ```lua
-project_root_paths = {
-	".bzr",
-	".git",
-	".hg",
-	".svn",
-	"_FOSSIL_",
-	"package.json",
-}
+require('codeium').setup({
+	workspace_root = {
+		use_lsp = true,
+		find_root = nil,
+		paths = {
+			".bzr",
+			".git",
+			".hg",
+			".svn",
+			"_FOSSIL_",
+			"package.json",
+		}
+	}
+})
 ```
 
-You can replace this list by passing `project_root_paths` when calling `setup`. If none of these paths are
-found, the plugin will treat the current working directory as the root.
+The `find_root` function can help the plugin find the workspace root when you are not using Neovim's built-in LSP
+provider. For example, this snippet calls into `coc.nvim` to find the workspace root.
+
+```lua
+require('codeium').setup({
+	workspace_root = {
+		find_root = function()
+			return vim.fn.CocAction("currentWorkspacePath")
+		end
+	}
+})
+```
+
+
 
 ## Troubleshooting
 

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -442,8 +442,8 @@ function Server:new()
 			cursor_offset = 0,
 			text = text,
 			line_ending = line_ending,
-			absolute_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p"),
-			relative_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":"),
+			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
+			relative_path_migrate_me_to_workspace_uri = util.get_relative_path(bufnr),
 		}
 
 		request("RefreshContextForIdeAction", {
@@ -458,7 +458,7 @@ function Server:new()
 	end
 
 	function m.add_workspace()
-		local project_root = vim.fn.getcwd()
+		local project_root = util.get_project_root()
 		-- workspace already tracked by server
 		if workspaces[project_root] then
 			return

--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -443,7 +443,7 @@ function Server:new()
 			text = text,
 			line_ending = line_ending,
 			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
-			relative_path_migrate_me_to_workspace_uri = util.get_relative_path(bufnr),
+			workspace_uri = util.get_uri(util.get_project_root()),
 		}
 
 		request("RefreshContextForIdeAction", {
@@ -453,8 +453,7 @@ function Server:new()
 				notify.error("failed refresh context: " .. err.out)
 				return
 			end
-		end
-		)
+		end)
 	end
 
 	function m.add_workspace()

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -23,13 +23,17 @@ function M.defaults()
 		enable_index_service = true,
 		search_max_workspace_file_count = 5000,
 		file_watch_max_dir_count = 50000,
-		project_root_paths = {
-			".bzr",
-			".git",
-			".hg",
-			".svn",
-			"_FOSSIL_",
-			"package.json",
+		workspace_root = {
+			use_lsp = true,
+			find_root = nil,
+			paths = {
+				".bzr",
+				".git",
+				".hg",
+				".svn",
+				"_FOSSIL_",
+				"package.json",
+			},
 		},
 	}
 end

--- a/lua/codeium/config.lua
+++ b/lua/codeium/config.lua
@@ -23,6 +23,14 @@ function M.defaults()
 		enable_index_service = true,
 		search_max_workspace_file_count = 5000,
 		file_watch_max_dir_count = 50000,
+		project_root_paths = {
+			".bzr",
+			".git",
+			".hg",
+			".svn",
+			"_FOSSIL_",
+			"package.json",
+		},
 	}
 end
 

--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -15,8 +15,8 @@ local function codeium_to_cmp(comp, offset, right)
 	local documentation = comp.completion.text
 
 	local label = documentation:sub(offset)
-	if label:sub(- #right) == right then
-		label = label:sub(1, - #right - 1)
+	if label:sub(-#right) == right then
+		label = label:sub(1, -#right - 1)
 	end
 
 	-- We get the completion part that has the largest offset
@@ -92,7 +92,7 @@ local function get_other_documents(bufnr)
 	local other_documents = {}
 
 	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-		if vim.api.nvim_buf_is_loaded(buf) and vim.bo[buf].filetype ~= '' and buf ~= bufnr then
+		if vim.api.nvim_buf_is_loaded(buf) and vim.bo[buf].filetype ~= "" and buf ~= bufnr then
 			table.insert(other_documents, buf_to_codeium(buf))
 		end
 	end
@@ -187,7 +187,7 @@ function Source:complete(params, callback)
 			language = language,
 			cursor_position = { row = cursor.row - 1, col = cursor.col - 1 },
 			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
-			workspace_uri = util.get_uri(util.get_relative_path(bufnr)),
+			workspace_uri = util.get_uri(util.get_project_root()),
 			line_ending = line_ending,
 			cursor_offset = cursor_offset,
 		},
@@ -205,7 +205,6 @@ function Source:complete(params, callback)
 			end
 		end
 	)
-
 end
 
 return Source

--- a/lua/codeium/util.lua
+++ b/lua/codeium/util.lua
@@ -1,7 +1,6 @@
 local enums = require("codeium.enums")
 local config = require("codeium.config")
 local io = require("codeium.io")
-local Path = require("plenary.path")
 local M = {}
 
 function M.fallback_call(calls, with_filter, fallback_value)
@@ -35,13 +34,6 @@ end
 
 function M.get_newline(bufnr)
 	return enums.line_endings[vim.bo[bufnr].fileformat] or "\n"
-end
-
--- Get the relative path from the project root
-function M.get_relative_path(bufnr)
-	local buf_path = vim.api.nvim_buf_get_name(bufnr)
-	local start_path = M.get_project_root(bufnr)
-	return Path:new(buf_path):make_relative(start_path)
 end
 
 local cached_roots = {}

--- a/lua/codeium/util.lua
+++ b/lua/codeium/util.lua
@@ -1,5 +1,7 @@
 local enums = require("codeium.enums")
+local config = require("codeium.config")
 local io = require("codeium.io")
+local Path = require("plenary.path")
 local M = {}
 
 function M.fallback_call(calls, with_filter, fallback_value)
@@ -19,13 +21,13 @@ function M.get_editor_options(bufnr)
 
 	return {
 		tab_size = M.fallback_call({
-			{ vim.api.nvim_get_option_value, "shiftwidth", { buf = bufnr, } },
-			{ vim.api.nvim_get_option_value, "tabstop",    { buf = bufnr, } },
+			{ vim.api.nvim_get_option_value, "shiftwidth", { buf = bufnr } },
+			{ vim.api.nvim_get_option_value, "tabstop", { buf = bufnr } },
 			{ vim.api.nvim_get_option_value, "shiftwidth" },
 			{ vim.api.nvim_get_option_value, "tabstop" },
 		}, greater_than_zero, 4),
 		insert_spaces = M.fallback_call({
-			{ vim.api.nvim_get_option_value, "expandtab", { buf = bufnr, } },
+			{ vim.api.nvim_get_option_value, "expandtab", { buf = bufnr } },
 			{ vim.api.nvim_get_option_value, "expandtab" },
 		}, nil, true),
 	}
@@ -35,8 +37,39 @@ function M.get_newline(bufnr)
 	return enums.line_endings[vim.bo[bufnr].fileformat] or "\n"
 end
 
+-- Get the relative path from the project root
 function M.get_relative_path(bufnr)
-	return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":")
+	local buf_path = vim.api.nvim_buf_get_name(bufnr)
+	local start_path = M.get_project_root()
+	return Path:new(buf_path):make_relative(start_path)
+end
+
+local cached_roots = {}
+function M.get_project_root()
+	local cwd = vim.fn.getcwd()
+
+	if cached_roots[cwd] then
+		return cached_roots[cwd]
+	end
+
+	-- From the CWD, walk up the tree looking for a directory that contains one of the project root files
+	local candidates = config.options.project_root_paths
+	local result = vim.fs.find(candidates, {
+		path = cwd,
+		upward = true,
+		limit = 1,
+	})
+
+	local found = result[1]
+	local dir
+	if found then
+		dir = vim.fs.dirname(found)
+	else
+		dir = cwd
+	end
+
+	cached_roots[cwd] = dir
+	return dir
 end
 
 function M.get_uri(path)


### PR DESCRIPTION
This provides a few methods of finding the workspace root (see comment below) and updates the calls that use `workspace_uri` to use it.


Closes #244 
Closes #238 
Supersedes #243 