### PR TITLE
Don't report error on 504 (timeout)

### DIFF
--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -376,7 +376,7 @@ function Server:new()
 			other_documents = other_documents,
 		}, function(body, err)
 			if err then
-				if err.status == 503 or err.status == 408 then
+				if err.status == 503 or err.status == 504 or err.status == 408 then
 					-- Service Unavailable or Timeout error
 					return complete(false, nil)
 				end


### PR DESCRIPTION
On an unstable Internet connection (for example in a train) the codeium requests sometimes timeouts returning a status code of 504. If this results in error message being spammed into neovim, it is very annoying.