### PR TITLE
Set an undo point before any virtual text completion

### DIFF
--- a/lua/codeium/virtual_text.lua
+++ b/lua/codeium/virtual_text.lua
@@ -173,7 +173,7 @@ local function completion_inserter(current_completion, insert_text)
 
 	server.accept_completion(current_completion.completion.completionId)
 
-	return delete_range .. insert_text .. cursor_text
+	return '<C-g>u' .. delete_range .. insert_text .. cursor_text
 end
 
 function M.accept()


### PR DESCRIPTION
This ensures that pressing undo after accepting a completion will only undo the completion, and not any other text that was typed before it.

Windsurf helped me make this change :)