### PR TITLE
fix: ignore buf without file path

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -123,6 +123,12 @@ function Source:complete(params, callback)
 	local line_ending = util.get_newline(bufnr)
 	local line_ending_len = utf8len(line_ending)
 	local editor_options = util.get_editor_options(bufnr)
+	local buf_name = vim.api.nvim_buf_get_name(bufnr)
+
+	if buf_name == "" then
+		callback(nil)
+		return
+	end
 
 	-- We need to calculate the number of bytes prior to the current character,
 	-- that starts with all the prior lines
@@ -163,7 +169,7 @@ function Source:complete(params, callback)
 			editor_language = filetype,
 			language = language,
 			cursor_position = { row = cursor.row - 1, col = cursor.col - 1 },
-			absolute_uri = util.get_uri(vim.api.nvim_buf_get_name(bufnr)),
+			absolute_uri = util.get_uri(buf_name),
 			workspace_uri = util.get_uri(util.get_project_root()),
 			line_ending = line_ending,
 			cursor_offset = cursor_offset,


### PR DESCRIPTION
Fix for completions errors on buffers without an actual file on the filesystem
Fixes #262
