### PR TITLE
Fix error installing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Feel free to create an issue/PR if you want to see anything else implemented.
 ```lua
 use {
     "Exafunction/codeium.nvim",
+	as = "codeium",
     requires = {
         "nvim-lua/plenary.nvim",
         "hrsh7th/nvim-cmp",
@@ -51,6 +52,7 @@ use {
 ```lua
 {
     "Exafunction/codeium.nvim",
+	name = "codeium",
     dependencies = {
         "nvim-lua/plenary.nvim",
         "hrsh7th/nvim-cmp",


### PR DESCRIPTION
since the setup is 

```lua
require("codeium").setup({})
```
we should alias the plugin name as "codeium". Otherwise the above call won't work


thanks for the great plugin though. jump to many and always comeback to yours