### PR TITLE
Stop spamming logs if plenary fails to spawn curl

### DIFF
--- a/lua/codeium/io.lua
+++ b/lua/codeium/io.lua
@@ -343,7 +343,7 @@ function M.gunzip(path, callback)
 			vim.o.shell = "powershell"
 		end
 		vim.o.shellcmdflag =
-		"-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
+			"-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
 		vim.o.shellredir = "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode"
 		vim.o.shellpipe = "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode"
 		vim.o.shellquote = ""
@@ -402,9 +402,9 @@ function M.post(url, params)
 	local tmpfname = os.tmpname()
 
 	if type(params.body) == "table" then
-		local f = io.open(tmpfname, 'w+')
+		local f = io.open(tmpfname, "w+")
 		if f == nil then
-			log.error('Cannot open temporary message file: ' .. tmpfname)
+			log.error("Cannot open temporary message file: " .. tmpfname)
 			return
 		end
 		f:write(vim.fn.json_encode(params.body))
@@ -437,7 +437,16 @@ function M.post(url, params)
 		end
 	end
 
-	curl.post(url, params)
+	local ok, obj = pcall(curl.post, url, params)
+	if not ok then
+		local err = tostring(obj)
+		if err:find("Failed to spawn process") then
+			local reason = err:gsub('pid = "(.*)"', "%1")
+			vim.notify("Failed to spawn curl: " .. reason, vim.log.levels.ERROR)
+		else
+			error(err)
+		end
+	end
 end
 
 function M.shell_open(url)


### PR DESCRIPTION
This turns this error message:
```lua
Error executing vim.schedule lua callback: .../.local/share/nvim/lazy/plenary.nvim/lua/plenary/job.lua:406: Failed to spaw
  _additional_on_exit_callbacks = {},
  _shutdown_check = <userdata 1>,
  _stderr_results = {},
  _stdout_results = {},
  _user_on_exit = <function 1>,
  args = { "-sSL", "-D", "/run/user/1000/plenary_curl_bc5048ce.headers", "-X", "POST", "-H", "Content-Type: application/json", "ua_dXDQAJ", "http://127.0.0.1:40309/exa.language_server_pb.LanguageServerService/Heartbeat" },
  command = "curl",
  enable_handlers = true,
  enable_recording = true,
  interactive = true,
  pid = "EMFILE: too many open files",
  stderr = <userdata 2>,
  stdin = <userdata 3>,
  stdout = <userdata 4>,
  user_data = {},
  <metatable> = <1>{
    __index = <table 1>,
    _create_uv_options = <function 2>,
    _execute = <function 3>,
    _pipes_are_closed = <function 4>,
    _prepare_pipes = <function 5>,
    _reset = <function 6>,
    _shutdown = <function 7>,
    _stop = <function 8>,
    add_on_exit_callback = <function 9>,
    after = <function 10>,
    after_failure = <function 11>,
    after_success = <function 12>,
    and_then = <function 13>,
    and_then_on_failure = <function 14>,
    and_then_on_failure_wrap = <function 15>,
    and_then_on_success = <function 16>,
    and_then_on_success_wrap = <function 17>,
    and_then_wrap = <function 18>,
    chain = <function 19>,
    chain_status = <function 20>,
    co_wait = <function 21>,
    is_job = <function 22>,
    join = <function 23>,
    new = <function 24>,
    pid = <function 25>,
    result = <function 26>,
    send = <function 27>,
    shutdown = <function 28>,
    start = <function 29>,
    stderr_result = <function 30>,
    sync = <function 31>,
    wait = <function 32>
  }
}
stack traceback:
        .../.local/share/nvim/lazy/plenary.nvim/lua/plenary/job.lua:406: in function '_execute'
        .../.local/share/nvim/lazy/plenary.nvim/lua/plenary/job.lua:449: in function 'start'
        ....local/share/nvim/lazy/plenary.nvim/lua/plenary/curl.lua:323: in function 'post'
        ...z/.local/share/nvim/lazy/codeium.nvim/lua/codeium/io.lua:440: in function 'post'
        .../.local/share/nvim/lazy/codeium.nvim/lua/codeium/api.lua:172: in function 'request'
        .../.local/share/nvim/lazy/codeium.nvim/lua/codeium/api.lua:179: in function 'do_heartbeat'
        .../.local/share/nvim/lazy/codeium.nvim/lua/codeium/api.lua:316: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
stack traceback:
        [C]: in function 'error'
        .../.local/share/nvim/lazy/plenary.nvim/lua/plenary/job.lua:406: in function '_execute'
        .../.local/share/nvim/lazy/plenary.nvim/lua/plenary/job.lua:449: in function 'start'
        ....local/share/nvim/lazy/plenary.nvim/lua/plenary/curl.lua:323: in function 'post'
        ...z/.local/share/nvim/lazy/codeium.nvim/lua/codeium/io.lua:440: in function 'post'
        .../.local/share/nvim/lazy/codeium.nvim/lua/codeium/api.lua:172: in function 'request'
        .../.local/share/nvim/lazy/codeium.nvim/lua/codeium/api.lua:179: in function 'do_heartbeat'
        .../.local/share/nvim/lazy/codeium.nvim/lua/codeium/api.lua:316: in function ''
```

In to:
```
Failed to spawn curl: EMFILE: too many open files
```

This way, Plenary stops spamming the error logs should curl fail to spawn. Without this change, Neovim would hang on quit because it now has to parse thousands of error messages and pipe them into the scroller. 