### PR TITLE
Fix: Fixed issue with carriage return (^M) being included in completions

### DIFF
--- a/lua/codeium/enums.lua
+++ b/lua/codeium/enums.lua
@@ -1,6 +1,6 @@
 return {
 	line_endings = {
-		dos = "\r\n",
+		dos = "\n",
 		unix = "\n",
 		mac = "\r",
 	},


### PR DESCRIPTION
This fixes #168 and is a simple one line change.