### PR TITLE
fix: prevent crash when encoding payload with invalid UTF-8

### DIFF
--- a/lua/codeium/io.lua
+++ b/lua/codeium/io.lua
@@ -343,7 +343,7 @@ function M.gunzip(path, callback)
 			vim.o.shell = "powershell"
 		end
 		vim.o.shellcmdflag =
-		"-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
+			"-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
 		vim.o.shellredir = "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode"
 		vim.o.shellpipe = "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode"
 		vim.o.shellquote = ""
@@ -402,12 +402,18 @@ function M.post(url, params)
 	local tmpfname = os.tmpname()
 
 	if type(params.body) == "table" then
-		local f = io.open(tmpfname, 'w+')
-		if f == nil then
-			log.error('Cannot open temporary message file: ' .. tmpfname)
+		local ok, json = pcall(vim.fn.json_encode, params.body)
+		if not ok then
+			log.error("Failed to encode Codeium payload (invalid UTF-8?)")
 			return
 		end
-		f:write(vim.fn.json_encode(params.body))
+
+		local f = io.open(tmpfname, "w+")
+		if f == nil then
+			log.error("Cannot open temporary message file: " .. tmpfname)
+			return
+		end
+		f:write(json)
 		f:close()
 
 		params.headers = params.headers or {}


### PR DESCRIPTION
### Summary

This PR wraps `vim.fn.json_encode()` in a `pcall()` to avoid crashing when Codeium tries to encode invalid UTF-8 payloads.

### Problem

Some buffers (e.g., minified `.mjs`, `.sum`, or binary-like files) contain invalid UTF-8. Codeium tries to encode the completion request payload with `vim.fn.json_encode`, leading to:

Vim:E474: String contains byte that does not start any UTF-8 character


### Fix

- Wraps the encoding with `pcall`.
- Logs a meaningful error and returns early if encoding fails.

Tested locally with such files, and Codeium no longer crashes.

Fixes a class of bugs seen when using preview panels or telescope buffers as well.
