### PR TITLE
fix: correct fallback_call filter logic

### DIFF
--- a/lua/codeium/util.lua
+++ b/lua/codeium/util.lua
@@ -6,7 +6,7 @@ local M = {}
 function M.fallback_call(calls, with_filter, fallback_value)
 	for _, i in ipairs(calls) do
 		local ok, result = pcall(unpack(i))
-		if ok and (with_filter ~= nil and with_filter(result)) then
+		if ok and (with_filter == nil or with_filter(result)) then
 			return result
 		end
 	end


### PR DESCRIPTION
Incorrect logic causes the function `fallback_call` to always return `fallback_value` when `with_filter` is nil