### PR TITLE
fix(virtual_text): Use <Tab> for default completion fallback

### DIFF
--- a/lua/codeium/virtual_text.lua
+++ b/lua/codeium/virtual_text.lua
@@ -137,7 +137,7 @@ function M.get_completion_text()
 end
 
 local function completion_inserter(current_completion, insert_text)
-	local default = config.options.virtual_text.accept_fallback or (vim.fn.pumvisible() == 1 and "<C-N>" or "\t")
+	local default = config.options.virtual_text.accept_fallback or (vim.fn.pumvisible() == 1 and "<C-N>" or "<Tab>")
 
 	if not (vim.fn.mode():match("^[iR]")) then
 		return default


### PR DESCRIPTION
The literal tab character `\t` can be ambiguous and is not always interpreted as the Tab key in all contexts.

Using `<Tab>` ensures that the action correctly simulates pressing the Tab key, providing a more robust and predictable fallback for accepting completions.