### PR TITLE
Trigger redraw_status_line when waiting

### DIFF
--- a/lua/codeium/virtual_text.lua
+++ b/lua/codeium/virtual_text.lua
@@ -173,7 +173,7 @@ local function completion_inserter(current_completion, insert_text)
 
 	server:accept_completion(current_completion.completion.completionId)
 
-	return '<C-g>u' .. delete_range .. insert_text .. cursor_text
+	return "<C-g>u" .. delete_range .. insert_text .. cursor_text
 end
 
 function M.accept()
@@ -437,6 +437,7 @@ function M.complete(opts)
 	local request_id = request_nonce
 
 	codeium_status = "waiting"
+	M.redraw_status_line()
 
 	local cancel = server:request_completion(
 		data.document,


### PR DESCRIPTION
I am trying to implement the statusline for codeium status. 
According to the documentation we has three state "idle", "waiting", and "completions" and we should register update callback by calling
```lua 	

require("codeium.virtual_text").set_statusbar_refresh(function()
 --- do something here
end)

```
But I realize that I never receive "waiting".
The status flips directly between "idle" and "completions", with no intermediate state.

So I created this PR for fixed this problem.